### PR TITLE
Lesson 05 - Hot module replacement

### DIFF
--- a/revents/src/index.js
+++ b/revents/src/index.js
@@ -4,12 +4,19 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
+const rootEl = document.getElementById('root');
+
+function render() {
+    ReactDOM.render(<App />, rootEl);
+}
+
+if (module.hot) {
+    module.hot.accept('./App', function () {
+        setTimeout(render)
+    })
+}
+
+render();
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
It's necessary to enable for improve the refresh of the page. 

With this, it's not necessary to do a full refresh, but only a refresh to an specific module.